### PR TITLE
Small Amendment to Rule 1

### DIFF
--- a/Board/01-Procedural-Item-Approval.md
+++ b/Board/01-Procedural-Item-Approval.md
@@ -35,3 +35,4 @@
 10. For greater certainty, if unanimous consent is sought and granted for a Substantive Action, the action is not considered approved.
 11. It is not a failure of the Speaker if they negligently seak unanimous consent on a Substantive Action, unless they actually knew, or should have known the action was considered substantive. 
 12. For greater certainty, objections raised by non-members in attendance do not impact the ability to obtain unanimous consent.
+13. Except where explicitly requested, clauses 7-12 shall not apply to an action to reject admission of an outside attendee from a meeting, or to expell an outside attendee from a meeting.


### PR DESCRIPTION
Fix an issue in Rule 1 where removal of an outside attendee can happen automatically. Clarified it to only happen if a member explicitly requests the attendee be removed/rejected.