### PR TITLE
Add executive/board restriction regulations

### DIFF
--- a/Board/04-Executive-Nominees-Club-Membership.md
+++ b/Board/04-Executive-Nominees-Club-Membership.md
@@ -1,0 +1,17 @@
+# Executive Nominees shall be Club Members
+
+1. The Board by regulation makes the following reasonable restriction on nominees for the positions of President, Vice President, and Treasurer (The Executive Positions)
+
+## Definitions
+
+2. General Member shall mean a General Member of the VGDC as defined by and admitted by the President of the VGDC.
+
+3. Club Member shall mean a Board Member, Executive Member, or General Member.
+
+4. VGDC Discord shall mean the official Discord Server of the VGDC, or such other primary forum of communication as designated by the Head of Community
+
+## Restriction
+
+5. Any person who voluntarily nominates themself for a ballot that includes any of the Executive Positions shall be included on that ballot only if that person is a Club Member who is a member of the VGDC Discord and who has set their display name to their name on record with the University of Windsor, or who has an exemption granted by the President of the VGDC.
+
+6. The Head of Operations shall ensure that all nominees on such a ballot described in (5) shall meet the requirements set out by this regulation.

--- a/Board/05-Board-Nominees-Club-Membership.md
+++ b/Board/05-Board-Nominees-Club-Membership.md
@@ -1,0 +1,17 @@
+# Board Nominees shall be Club Members
+
+1. The Board by regulation makes the following reasonable restriction on nominees for the Board Positions, defined by the Constitution of the VGDC or by the Board by regulation.
+
+## Definitions
+
+2. General Member shall mean a General Member of the VGDC as defined by and admitted by the President of the VGDC.
+
+3. Club Member shall mean a Board Member, Executive Member, or General Member.
+
+4. VGDC Discord shall mean the official Discord Server of the VGDC, or such other primary forum of communication as designated by the Head of Community
+
+## Restriction
+
+5. Any person who voluntarily nominates themself for a ballot that includes any of the Board Positions shall be included on that ballot only if that person is a Club Member who is a member of the VGDC Discord and who has set their display name to their name on record with the University of Windsor, or who has an exemption granted by the President of the VGDC.
+
+6. The Head of Operations shall ensure that all nominees on such a ballot described in (5) shall meet the requirements set out by this regulation.

--- a/Board/06-Executive-Nominees-Not-Previously-Removed.md
+++ b/Board/06-Executive-Nominees-Not-Previously-Removed.md
@@ -1,0 +1,23 @@
+# Executive Nominees shall not have been previously removed
+
+1. The Board by regulation makes the following reasonable restriction on nominees for the Positions of President, Vice President, or Treasurer.
+
+## Definitions
+
+2. Previous Board Position shall mean a Board Position defined by the Constitution of the VGDC or by the Board at the current time or at the time a nominee held such a position.
+
+3. Board or Executive Positon shall mean either a Previous Board Position or an Executive Position
+
+## Restriction
+
+5. Any person who voluntarily nominates themself for a ballot that includes any of the Executive Positions shall not be included on the ballot if that person previously held a Board or Executive Position and was removed by the Board by a motion of non-confidence or by a removal order.
+
+6. The Head of Operations shall ensure that all nominees on such a ballot described in (5) shall meet the requirements set out by this regulation.
+
+## Resignation does not disqualify
+
+7. A person shall not be disqualified if the person was previously removed from an Executive or Board Position as a result of that person voluntarily resigning the position, unless the person resigned in response to a motion of non-confidence or removal order which the Board confirms to disqualify by *simple-majority*.
+
+## Disbanding of Executive does not disqualify
+
+8. A person shall not be disqualified if the person was removed from an Executive Position as a result of a Board motion to disband the executive, unless the Board disqualifies that person by *simple-majority*.

--- a/Board/07-Board-Nominees-Not-Previously-Removed.md
+++ b/Board/07-Board-Nominees-Not-Previously-Removed.md
@@ -1,0 +1,23 @@
+# Board Nominees shall not have been previously removed
+
+1. The Board by regulation makes the following reasonable restriction on nominees for the Board Positions, defined by the Constitution of the VGDC or by the Board by regulation.
+
+## Definitions
+
+2. Previous Board Position shall mean a Board Position defined by the Constitution of the VGDC or by the Board at the current time or at the time a nominee held such a position.
+
+3. Board or Executive Positon shall mean either a Previous Board Position or an Executive Position
+
+## Restriction
+
+5. Any person who voluntarily nominates themself for a ballot that includes any of the Board Positions shall not be included on the ballot if that person previously held a Board or Executive Position and was removed by the Board by a motion of non-confidence or by a removal order.
+
+6. The Head of Operations shall ensure that all nominees on such a ballot described in (5) shall meet the requirements set out by this regulation.
+
+## Resignation does not disqualify
+
+7. A person shall not be disqualified if the person was previously removed from an Executive or Board Position as a result of that person voluntarily resigning the position, unless the person resigned in response to a motion of non-confidence or removal order which the Board confirms to disqualify by *simple-majority*.
+
+## Disbanding of Executive does not disqualify
+
+8. A person shall not be disqualified if the person was removed from an Executive Position as a result of a Board motion to disband the executive, unless the Board disqualifies that person by *simple-majority*.


### PR DESCRIPTION
This places (separately) the following restrictions on both Board and Executive Nominees:
1. Board and Executive Nominees shall be Club Members
2. Board and Executive Nominees shall not have been previously removed from their positions.