### PR TITLE
Set succession order for President and Treasurer by Regulation

### DIFF
--- a/Board/19-Succession-Order.md
+++ b/Board/19-Succession-Order.md
@@ -4,5 +4,5 @@
 
 ## §1 Succesion Orders
 
-1. The Succession order for President shall be: Vice President, Treasurer, Head of Operations, Head of Community, Head of Events, Head of Development.
+1. The Succession order for President shall be: Vice President, Head of Operations, Head of Community, Head of Events, Head of Development.
 2. The Succession order for Treasurer shall be: Head of Events, Head of Development, Head of Operations, Head of Community.

--- a/Board/19-Succession-Order.md
+++ b/Board/19-Succession-Order.md
@@ -1,0 +1,8 @@
+# Succession Order
+
+1. Whereas the Constitution grants the Board the Authority to set the succession order for the positions of President and Treasurer, but otherwise sets a default succession order, the Board Establishes the Following.
+
+## §1 Succesion Orders
+
+1. The Succession order for President shall be: Vice President, Treasurer, Head of Operations, Head of Community, Head of Events, Head of Development.
+2. The Succession order for Treasurer shall be: Head of Events, Head of Development, Head of Operations, Head of Community.


### PR DESCRIPTION
This sets the President succession order to differ from the default by removing the Treasurer from the Succession Order. It additionally sets the Treasurer succession order to the default explicitly.